### PR TITLE
feat: 添加 GitHub Actions CI 支持

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -66,12 +66,12 @@ jobs:
       run: |
         Move-Item -Path TuneLab\bin\${{ matrix.configuration }}\net8.0 -Destination workspace
 
-    - name: Package artifacts
+    - name: Pack artifacts
       shell: pwsh
       run: |
         Compress-Archive -Path workspace\* -DestinationPath ${env:ARCHIVE_NAME}'.zip'
 
-    - name: Upload built zip
+    - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARCHIVE_NAME }}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -17,7 +17,8 @@ jobs:
 
     strategy:
       matrix:
-        configuration: [Release] # [Debug, Release]
+        configuration: [ "Release" ] # [Debug, Release]
+        runtime: [ "win-x64" ]
 
     runs-on: windows-latest
 
@@ -51,7 +52,7 @@ jobs:
 
     - name: Set short SHA as package name
       if: "!startsWith(github.event.ref, 'refs/tags/')"
-      run: echo "ARCHIVE_NAME=TuneLab-win-x64-$(git rev-parse --short HEAD)" >> $env:GITHUB_ENV
+      run: echo "ARCHIVE_NAME=TuneLab-${{ matrix.runtime }}-$(git rev-parse --short HEAD)" >> $env:GITHUB_ENV
       
     - name: Set tag version into env
       if: startsWith(github.event.ref, 'refs/tags/')
@@ -59,12 +60,28 @@ jobs:
       
     - name: Set tag version as package name
       if: startsWith(github.event.ref, 'refs/tags/')
-      run: echo "ARCHIVE_NAME=TuneLab-win-x64-${env:TAG_NAME}" >> $env:GITHUB_ENV
+      run: echo "ARCHIVE_NAME=TuneLab-${{ matrix.runtime }}-${env:TAG_NAME}" >> $env:GITHUB_ENV
+
+    - name: Split runtimes
+      shell: pwsh
+      run: |
+        Move-Item -Path TuneLab\bin\${{ matrix.configuration }}\net8.0\runtimes -Destination runtimes
 
     - name: Move artifacts
       shell: pwsh
       run: |
         Move-Item -Path TuneLab\bin\${{ matrix.configuration }}\net8.0 -Destination workspace
+
+    - name: Prepare runtime directory
+      shell: pwsh
+      run: |
+        # Prepare workspace dir
+        New-Item -ItemType Directory workspace\runtimes
+
+    - name: Copy specific runtime only
+      shell: pwsh
+      run: |
+        Move-Item -Path runtimes\${{ matrix.runtime }} -Destination workspace\runtimes\${{ matrix.runtime }}
 
     - name: Pack artifacts
       shell: pwsh


### PR DESCRIPTION
## 优势

1. 可以在每一次提交到 master branch 的时候都自动打包一个环境（在 Actions 对应运行的 Artifacts 里下载，比如 https://github.com/Candinya/TuneLab/actions/runs/9043341125 这里最底下），作为 nightly 构建或是临时测试构建等等，方便没有本地构建环境的用户调试或尝试新特性使用；也可以方便黑盒测试提交的 PR （尤其是一些修改很大不方便目视检查的）是否能成功构建及是否存在破坏性改动等（可能需要在未来追加对应的 test case ）
2. 可以使用 tag 自动发版并构建版本对应的程序包，不再需要本地构建后打包上传

自动发版的默认格式如下图所示，它会创建成一个 draft release （不会直接发出去），在进一步编辑完成后再确认发布（也可以自由调整是否为 pre-release ）即可
![image](https://github.com/LiuYunPlayer/TuneLab/assets/20502130/21ba59d1-dd68-45cb-b83c-4815c1466eae)

## 注意事项

1. 暂时只做了 Windows 平台的 CI 适配，还没有做 macOS 和 Linux 平台的（等有空或者等一位有缘人了）
2. 如果现在是在 GitHub 上手动创建 Release 并自动生成 tag 的话，可能需要调整一下操作习惯（等于反过来了，原来是先有 release 再有 tag ，现在是先有 tag 再有 release ）
