### PR TITLE
feat(ci): 跨平台自动构建流水线

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -17,7 +17,6 @@ jobs:
 
     strategy:
       matrix:
-        configuration: [ "Release" ] # [Debug, Release]
         runtime: [ "win-x64" ]
 
     runs-on: windows-latest
@@ -28,27 +27,13 @@ jobs:
       with:
         fetch-depth: 0
 
-    # Install the .NET Core workload
     - name: Install .NET Core
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
 
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
-
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
-    - name: Restore the application
-      run: msbuild TuneLab.sln /t:Restore /p:Configuration=$env:Configuration
-      env:
-        Configuration: ${{ matrix.configuration }}
-
-    # Create the app package by building and packaging the Windows Application Packaging project
-    - name: Create the app package
-      run: msbuild TuneLab\TuneLab.csproj /p:Configuration=$env:Configuration
-      env:
-        Configuration: ${{ matrix.configuration }}
+    - name: Build the application
+      run: dotnet publish --configuration Release -r ${{ matrix.runtime }}
 
     - name: Set short SHA as package name
       if: "!startsWith(github.event.ref, 'refs/tags/')"
@@ -62,31 +47,13 @@ jobs:
       if: startsWith(github.event.ref, 'refs/tags/')
       run: echo "ARCHIVE_NAME=TuneLab-${{ matrix.runtime }}-${env:TAG_NAME}" >> $env:GITHUB_ENV
 
-    - name: Split runtimes
-      shell: pwsh
-      run: |
-        Move-Item -Path TuneLab\bin\${{ matrix.configuration }}\net8.0\runtimes -Destination runtimes
-
     - name: Move artifacts
       shell: pwsh
-      run: |
-        Move-Item -Path TuneLab\bin\${{ matrix.configuration }}\net8.0 -Destination workspace
-
-    - name: Prepare runtime directory
-      shell: pwsh
-      run: |
-        # Prepare workspace dir
-        New-Item -ItemType Directory workspace\runtimes
-
-    - name: Copy specific runtime only
-      shell: pwsh
-      run: |
-        Move-Item -Path runtimes\${{ matrix.runtime }} -Destination workspace\runtimes\${{ matrix.runtime }}
+      run: Move-Item -Path TuneLab\bin\Release\net8.0\${{ matrix.runtime }}\publish -Destination workspace
 
     - name: Pack artifacts
       shell: pwsh
-      run: |
-        Compress-Archive -Path workspace\* -DestinationPath ${env:ARCHIVE_NAME}'.zip'
+      run: Compress-Archive -Path workspace\* -DestinationPath ${env:ARCHIVE_NAME}'.zip'
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -94,13 +61,143 @@ jobs:
         name: ${{ env.ARCHIVE_NAME }}
         path: workspace
 
-    - name: Create release (draft)
+    - name: Upload release artifact
       if: startsWith(github.event.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ env.TAG_NAME }}
+        files: ${{ env.ARCHIVE_NAME }}.zip
+
+
+  build-macos:
+    name: Build macOS version
+
+    strategy:
+      matrix:
+        runtime: [ "osx-arm64" ]
+
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Build the application
+      run: dotnet publish --configuration Release -r ${{ matrix.runtime }}
+
+    - name: Set short SHA as package name
+      if: "!startsWith(github.event.ref, 'refs/tags/')"
+      run: echo "ARCHIVE_NAME=TuneLab-${{ matrix.runtime }}-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      
+    - name: Set tag version into env
+      if: startsWith(github.event.ref, 'refs/tags/')
+      run: echo "TAG_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
+      
+    - name: Set tag version as package name
+      if: startsWith(github.event.ref, 'refs/tags/')
+      run: echo "ARCHIVE_NAME=TuneLab-${{ matrix.runtime }}-$TAG_NAME" >> $GITHUB_ENV
+
+    - name: Move artifacts
+      run: mv TuneLab/bin/Release/net8.0/${{ matrix.runtime }}/publish workspace
+
+    - name: Pack artifacts
+      run: |
+        cd workspace
+        tar -zcvf ../$ARCHIVE_NAME.tar.gz .
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.ARCHIVE_NAME }}.tar.gz
+        path: ${{ env.ARCHIVE_NAME }}.tar.gz
+
+    - name: Upload release artifact
+      if: startsWith(github.event.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ env.TAG_NAME }}
+        files: ${{ env.ARCHIVE_NAME }}.tar.gz
+
+
+  build-linux:
+    name: Build Linux version
+
+    strategy:
+      matrix:
+        runtime: [ "linux-x64" ]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Build the application
+      run: dotnet publish --configuration Release -r ${{ matrix.runtime }}
+
+    - name: Set short SHA as package name
+      if: "!startsWith(github.event.ref, 'refs/tags/')"
+      run: echo "ARCHIVE_NAME=TuneLab-${{ matrix.runtime }}-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      
+    - name: Set tag version into env
+      if: startsWith(github.event.ref, 'refs/tags/')
+      run: echo "TAG_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
+      
+    - name: Set tag version as package name
+      if: startsWith(github.event.ref, 'refs/tags/')
+      run: echo "ARCHIVE_NAME=TuneLab-${{ matrix.runtime }}-$TAG_NAME" >> $GITHUB_ENV
+
+    - name: Move artifacts
+      run: mv TuneLab/bin/Release/net8.0/${{ matrix.runtime }}/publish workspace
+
+    - name: Pack artifacts
+      run: |
+        cd workspace
+        tar -zcvf ../$ARCHIVE_NAME.tar.gz .
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.ARCHIVE_NAME }}.tar.gz
+        path: ${{ env.ARCHIVE_NAME }}.tar.gz
+
+    - name: Upload release artifact
+      if: startsWith(github.event.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ env.TAG_NAME }}
+        files: ${{ env.ARCHIVE_NAME }}.tar.gz
+
+
+  prepare-release:
+    name: Prepare release
+    if: startsWith(github.event.ref, 'refs/tags/')
+    needs:
+      - build-windows
+      - build-macos
+      - build-linux
+    
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Create release (draft)
       uses: softprops/action-gh-release@v2
       with:
         name: TuneLab - ${{ env.TAG_NAME }}
         tag_name: ${{ env.TAG_NAME }}
         generate_release_notes: true
         draft: true
-        files: |
-          ${{ env.ARCHIVE_NAME }}.zip

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -194,4 +194,4 @@ jobs:
         draft: true
         files: |
           TuneLab-*.zip
-          TuneLab-*.tar.gz
+#          TuneLab-*.tar.gz    # 因为还没有解决跨平台的问题所以这个先注释掉，等跨平台完成了就可以去掉这个注释一并发布 linux 和 osx 的版本了

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -13,7 +13,7 @@ on:
 jobs:
 
   build-windows:
-    name: Build windows version
+    name: Build Windows version
 
     strategy:
       matrix:

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -61,12 +61,13 @@ jobs:
         name: ${{ env.ARCHIVE_NAME }}
         path: workspace
 
-    - name: Upload release artifact
+    - name: Upload release artifacts
       if: startsWith(github.event.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v2
+      uses: actions/upload-artifact@v4
       with:
-        tag_name: ${{ env.TAG_NAME }}
-        files: ${{ env.ARCHIVE_NAME }}.zip
+        name: ${{ env.ARCHIVE_NAME }}.zip
+        path: ${{ env.ARCHIVE_NAME }}.zip
+        retention-days: 1
 
 
   build-macos:
@@ -118,13 +119,6 @@ jobs:
         name: ${{ env.ARCHIVE_NAME }}.tar.gz
         path: ${{ env.ARCHIVE_NAME }}.tar.gz
 
-    - name: Upload release artifact
-      if: startsWith(github.event.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v2
-      with:
-        tag_name: ${{ env.TAG_NAME }}
-        files: ${{ env.ARCHIVE_NAME }}.tar.gz
-
 
   build-linux:
     name: Build Linux version
@@ -175,13 +169,6 @@ jobs:
         name: ${{ env.ARCHIVE_NAME }}.tar.gz
         path: ${{ env.ARCHIVE_NAME }}.tar.gz
 
-    - name: Upload release artifact
-      if: startsWith(github.event.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v2
-      with:
-        tag_name: ${{ env.TAG_NAME }}
-        files: ${{ env.ARCHIVE_NAME }}.tar.gz
-
 
   prepare-release:
     name: Prepare release
@@ -194,6 +181,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
+
     - name: Create release (draft)
       uses: softprops/action-gh-release@v2
       with:
@@ -201,3 +193,6 @@ jobs:
         tag_name: ${{ env.TAG_NAME }}
         generate_release_notes: true
         draft: true
+        files: |
+          TuneLab-*.zip
+          TuneLab-*.tar.gz

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -189,7 +189,7 @@ jobs:
     - name: Create release (draft)
       uses: softprops/action-gh-release@v2
       with:
-        name: TuneLab - ${{ env.TAG_NAME }}
+        name: TuneLab - ${{ env.GITHUB_REF_NAME }}
         tag_name: ${{ env.TAG_NAME }}
         generate_release_notes: true
         draft: true

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -189,8 +189,7 @@ jobs:
     - name: Create release (draft)
       uses: softprops/action-gh-release@v2
       with:
-        name: TuneLab - ${{ env.GITHUB_REF_NAME }}
-        tag_name: ${{ env.TAG_NAME }}
+        name: TuneLab - ${{ vars.GITHUB_REF_NAME }}
         generate_release_notes: true
         draft: true
         files: |

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -189,7 +189,7 @@ jobs:
     - name: Create release (draft)
       uses: softprops/action-gh-release@v2
       with:
-        name: TuneLab - ${{ vars.GITHUB_REF_NAME }}
+        name: TuneLab - ${{ github.ref_name }}
         generate_release_notes: true
         draft: true
         files: |


### PR DESCRIPTION
## 改进

1. 改进了原有的 CI 流程，优化了构建逻辑（不再需要重复安装 msbuild 环境及手动提取 runtime 目录了）
2. 新增了 macOS 和 Linux 平台下的流水线逻辑（使用默认平台配置，如果有其他平台需求可以在对应 job 的 runtime 里添加）

## 存在的问题

1. macOS 环境下没有打包成一个 App ，所以不方便使用。
2. macOS 和 Linux 环境下构建的结果无法启动运行，报缺 `winmm` 相关的动态链接库，不确定是 NAudio 的跨平台兼容问题还是 TuneLab.csproj 里提到的 TFM 问题（手上的 mac 试了试修改 TargetFramework ， dotnet SDK 默认使用的脚本路径不是 Xcode 的应用路径所以报找不到脚本的错误，不确定应该怎么调整并且不想在 mac 上装 VS 就没有深入研究下去），因此这两个平台只会在一般的流水线里构建出来，但不会在 tag 发布时候引入（什么时候问题解决了就可以删掉被注释掉的那一行来上传这两个平台的构建结果了）。
3. 为了避免下载 Artifact 的时候被 GitHub 二次压缩，在 Windows 的一般流水线构建是上传的无压缩目录，在打 tag 发布时为了传递构件会使用一个同名的临时 zip ；对 macOS 和 Linux 环境为了避免破坏掉可执行文件的权限所以使用的是 .tar.gz 压缩，下载 Artifact 会被 GitHub 二压一遍成 zip ；能用但有些难看。

## 注意事项

因为改了构建主逻辑（从 msbuild 改成了 dotnet publish ），所以需要再仔细确认一下 Windows 平台下的构建发布是否依旧功能完备，正常运行。（这边放到 Windows Sandbox 里面装好 dotnet 运行环境后能启动）

## 补充

虽然现在 macOS 和 Linux 的流水线步骤都是一样的，但未来针对不同的平台可能引入不同的改动（例如 macOS 打包成 App ， Linux 打包成 AppImage 这种），所以还是把它们拆开了。