### PR TITLE
歌词面板添加关闭按钮，并移除多余代码

### DIFF
--- a/TuneLab/GUI/Dialog.axaml
+++ b/TuneLab/GUI/Dialog.axaml
@@ -9,8 +9,7 @@
 		Height="204"
 		ExtendClientAreaChromeHints="NoChrome"
 		ExtendClientAreaTitleBarHeightHint="40"
-		ExtendClientAreaToDecorationsHint="True"
-		UseLayoutRounding="True">
+		ExtendClientAreaToDecorationsHint="True">
 		<Window.Styles>
 			<Style Selector="TitleBar">
 				<Setter Property="Background" Value="DarkGray"/>

--- a/TuneLab/TuneLab.csproj
+++ b/TuneLab/TuneLab.csproj
@@ -45,5 +45,8 @@
 	  <Compile Update="Views\MainWindow.axaml.cs">
 	    <DependentUpon>MainWindow.axaml</DependentUpon>
 	  </Compile>
+	  <Compile Update="Views\LyricInput.axaml.cs">
+		<DependentUpon>LyricInput.axaml</DependentUpon>
+	  </Compile>
 	</ItemGroup>
 </Project>

--- a/TuneLab/Views/LyricInput.axaml
+++ b/TuneLab/Views/LyricInput.axaml
@@ -19,7 +19,7 @@
 				<ColumnDefinition Width="*"/>
 			</Grid.ColumnDefinitions>
 			
-			<StackPanel Grid.Column="0" x:Name="MenuBar" HorizontalAlignment="Left" VerticalAlignment="Center" Orientation="Horizontal" IsHitTestVisible="False"/>
+			<StackPanel Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center" Orientation="Horizontal" IsHitTestVisible="False"/>
 			<StackPanel Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Orientation="Horizontal" IsHitTestVisible="False">
 				<Label Content="Input Lyrics" x:Name="TitleLabel" FontWeight="Bold" FontSize="14" VerticalAlignment="Center" BorderThickness="0" IsHitTestVisible="False"/>
 			</StackPanel>
@@ -27,7 +27,7 @@
 		</Grid>
 
 		<ContentControl>
-			<Grid Width="480" Height="244" DockPanel.Dock="Bottom">
+			<Grid Width="480" Height="244">
 				<Grid.RowDefinitions>
 					<RowDefinition Height="184" />
 					<RowDefinition Height="28" />

--- a/TuneLab/Views/LyricInput.axaml
+++ b/TuneLab/Views/LyricInput.axaml
@@ -4,46 +4,44 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" d:DesignWidth="480" d:DesignHeight="284"
         x:Class="TuneLab.Views.LyricInput"
-        Title="TuneLab"
+        Title="Input Lyric - TuneLab"
 		Width="480"
 		Height="284"
 		ExtendClientAreaChromeHints="NoChrome"
 		ExtendClientAreaTitleBarHeightHint="40"
-		ExtendClientAreaToDecorationsHint="True"
-		UseLayoutRounding="True">
-	<Window.Styles>
-		<Style Selector="TitleBar">
-			<Setter Property="Background" Value="DarkGray"/>
-			<Setter Property="Foreground" Value="White"/>
-		</Style>
-		<Style Selector="Window">
-			<Setter Property="CornerRadius" Value="12"/>
-		</Style>
-	</Window.Styles>
-
-	<DockPanel Margin="0">
-		<Grid DockPanel.Dock="Top" IsHitTestVisible="False" x:Name="TitleBar" Height="40">
+		ExtendClientAreaToDecorationsHint="True">
+	
+	<DockPanel>
+		<Grid DockPanel.Dock="Top" Height="40" x:Name="TitleBar">
 			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="*"/>
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="*"/>
 			</Grid.ColumnDefinitions>
-
-			<Label x:Name="TitleLabel" Content="Input Lyrics" FontWeight="Bold" FontSize="14" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="White" />
+			
+			<StackPanel Grid.Column="0" x:Name="MenuBar" HorizontalAlignment="Left" VerticalAlignment="Center" Orientation="Horizontal" IsHitTestVisible="False"/>
+			<StackPanel Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Orientation="Horizontal" IsHitTestVisible="False">
+				<Label Content="Input Lyrics" x:Name="TitleLabel" FontWeight="Bold" FontSize="14" VerticalAlignment="Center" BorderThickness="0" IsHitTestVisible="False"/>
+			</StackPanel>
+			<StackPanel Grid.Column="2" x:Name="WindowControl" HorizontalAlignment="Right" VerticalAlignment="Center" />
 		</Grid>
 
-		<Grid Margin="0">
-			<Grid.RowDefinitions>
-				<RowDefinition Height="184" />
-				<RowDefinition Height="28" />
-			</Grid.RowDefinitions>
+		<ContentControl>
+			<Grid Width="480" Height="244" DockPanel.Dock="Bottom">
+				<Grid.RowDefinitions>
+					<RowDefinition Height="184" />
+					<RowDefinition Height="28" />
+				</Grid.RowDefinitions>
 
-			<StackPanel Grid.Row="0" Orientation="Vertical" Margin="24, 16, 24, 16" HorizontalAlignment="Center" VerticalAlignment="Center" x:Name="TextareaBox" />
+				<StackPanel Grid.Row="0" Orientation="Vertical" Margin="24, 16, 24, 16" HorizontalAlignment="Center" VerticalAlignment="Center" x:Name="TextareaBox" />
 
-			<Grid Grid.Row="1" x:Name="ActionsPanel" Margin="24, 16, 24, 16">
-				<Grid.ColumnDefinitions>
-					<ColumnDefinition Width="*" />
-					<ColumnDefinition Width="Auto" />
-				</Grid.ColumnDefinitions>
+				<Grid Grid.Row="1" x:Name="ActionsPanel" Margin="24, 16, 24, 16">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="Auto" />
+					</Grid.ColumnDefinitions>
+				</Grid>
 			</Grid>
-		</Grid>
+		</ContentControl>
 	</DockPanel>
 </Window>

--- a/TuneLab/Views/LyricInput.axaml.cs
+++ b/TuneLab/Views/LyricInput.axaml.cs
@@ -14,7 +14,7 @@ namespace TuneLab.Views;
 
 internal partial class LyricInput : Window
 {
-    LyricInput()
+    public LyricInput()
     {
         InitializeComponent();
         Focusable = true;

--- a/TuneLab/Views/LyricInput.axaml.cs
+++ b/TuneLab/Views/LyricInput.axaml.cs
@@ -1,16 +1,14 @@
 using Avalonia.Controls;
-using Avalonia.Controls.Chrome;
-using System;
-using TuneLab.Utils;
-using TuneLab.GUI;
-using TuneLab.GUI.Components;
-using CheckBox = TuneLab.GUI.Components.CheckBox;
 using Avalonia.Layout;
-using Button = TuneLab.GUI.Components.Button;
 using Avalonia.Media;
-using TuneLab.Data;
 using System.Collections.Generic;
 using System.Linq;
+using TuneLab.Data;
+using TuneLab.GUI;
+using TuneLab.GUI.Components;
+using TuneLab.Utils;
+using Button = TuneLab.GUI.Components.Button;
+using CheckBox = TuneLab.GUI.Components.CheckBox;
 
 namespace TuneLab.Views;
 
@@ -25,9 +23,16 @@ internal partial class LyricInput : Window
         WindowStartupLocation = WindowStartupLocation.CenterScreen;
         Topmost = true;
 
-        this.DataContext = this;
         this.Background = Style.INTERFACE.ToBrush();
         TitleBar.Background = Style.BACK.ToBrush();
+        TitleLabel.Foreground = Style.TEXT_LIGHT.ToBrush();
+
+        var closeButton = new Button() { Width = 48, Height = 40 }
+                .AddContent(new() { Item = new BorderItem() { CornerRadius = 0 }, ColorSet = new() { HoveredColor = Colors.White.Opacity(0.2), PressedColor = Colors.White.Opacity(0.2) } })
+                .AddContent(new() { Item = new IconItem() { Icon = Assets.WindowClose }, ColorSet = new() { Color = Style.TEXT_LIGHT.Opacity(0.7) } });
+        closeButton.Clicked += () => Close();
+
+        WindowControl.Children.Add(closeButton);
 
         mLyricInputBox = new TextInput();
         mLyricInputBox.AcceptsReturn = true;

--- a/TuneLab/Views/MainWindow.axaml
+++ b/TuneLab/Views/MainWindow.axaml
@@ -10,17 +10,7 @@
 		ExtendClientAreaChromeHints="NoChrome"
 		ExtendClientAreaTitleBarHeightHint="40"
 		ExtendClientAreaToDecorationsHint="True"
-		UseLayoutRounding="True"
 		SizeChanged="Window_SizeChanged">
-	<Window.Styles>
-		<Style Selector="TitleBar">
-			<Setter Property="Background" Value="DarkGray"/>
-			<Setter Property="Foreground" Value="White"/>
-		</Style>
-		<Style Selector="Window">
-			<Setter Property="CornerRadius" Value="20"/>
-		</Style>
-	</Window.Styles>
 
 	<DockPanel Margin="{Binding $parent[Window].OffScreenMargin}">
 		<!-- Custom title bar -->

--- a/TuneLab/Views/MainWindow.axaml.cs
+++ b/TuneLab/Views/MainWindow.axaml.cs
@@ -37,7 +37,7 @@ namespace TuneLab.Views
             this.AttachDevTools();
 #endif
 
-            Focusable = true;
+            Focusable = false;
             IsTabStop = false;
             isCloseConfirm = false;
             Background = Style.BACK.ToBrush();
@@ -129,7 +129,6 @@ namespace TuneLab.Views
                         }
                         break;
                     case WindowState.Minimized:
-                        Trace.WriteLine("窗口状态：最小化");
                         break;
                 }
 

--- a/TuneLab/Views/MainWindow.axaml.cs
+++ b/TuneLab/Views/MainWindow.axaml.cs
@@ -37,7 +37,7 @@ namespace TuneLab.Views
             this.AttachDevTools();
 #endif
 
-            Focusable = false;
+            Focusable = true;
             IsTabStop = false;
             isCloseConfirm = false;
             Background = Style.BACK.ToBrush();


### PR DESCRIPTION
子窗口拖拽问题还没解决，目前可以确定的是子窗口使用自定义TitleBar的时候会遮挡拖拽区域。