### PR TITLE
Add Artifacts Attestation

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -21,6 +21,11 @@ jobs:
 
     runs-on: windows-latest
 
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -84,6 +89,11 @@ jobs:
 
     runs-on: macos-latest
 
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -138,6 +148,11 @@ jobs:
         runtime: [ "linux-x64" ]
 
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
 
     steps:
     - name: Checkout

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -51,6 +51,11 @@ jobs:
       shell: pwsh
       run: Move-Item -Path TuneLab\bin\Release\net8.0\${{ matrix.runtime }}\publish -Destination workspace
 
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: '"workspace/*.dll","workspace/*.exe"'
+
     - name: Pack artifacts
       shell: pwsh
       run: Compress-Archive -Path workspace\* -DestinationPath ${env:ARCHIVE_NAME}'.zip'
@@ -108,6 +113,11 @@ jobs:
     - name: Move artifacts
       run: mv TuneLab/bin/Release/net8.0/${{ matrix.runtime }}/publish workspace
 
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: '"workspace/*.dll","workspace/ExtensionInstaller","workspace/TuneLab"'
+
     - name: Pack artifacts
       run: |
         cd workspace
@@ -157,6 +167,11 @@ jobs:
 
     - name: Move artifacts
       run: mv TuneLab/bin/Release/net8.0/${{ matrix.runtime }}/publish workspace
+
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: '"workspace/*.dll","workspace/ExtensionInstaller","workspace/TuneLab"'
 
     - name: Pack artifacts
       run: |


### PR DESCRIPTION
Add artifacts attestation provided by [@actions/attest][1] which is powered by [Sigstore][2] .

[1]: https://github.com/actions/toolkit/tree/main/packages/attest
[2]: https://www.sigstore.dev/