### PR TITLE
Fallback和插件与腰包功能

### DIFF
--- a/TuneLab/I18N/TomlTranslator.cs
+++ b/TuneLab/I18N/TomlTranslator.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices.ObjectiveC;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using Tomlyn;
@@ -12,8 +14,8 @@ namespace TuneLab.I18N;
 
 internal class TomlTranslator : ITranslator
 {
-    public TomlTranslator(string dictPath) => LoadDict(dictPath);
-    public void LoadDict(string dictPath)
+    public TomlTranslator(string dictPath, Dictionary<string, string>? subDict = null) => LoadDict(dictPath, subDict);
+    public void LoadDict(string dictPath,Dictionary<string,string>? subDict=null)
     {
         if (!File.Exists(dictPath))
             return;
@@ -21,6 +23,41 @@ internal class TomlTranslator : ITranslator
         string dictData = File.ReadAllText(dictPath);
         if (!Toml.TryToModel(dictData, out model, out var message)) 
             return;
+        if (subDict != null) foreach (var item in subDict) AppendDict(item.Key, item.Value);
+    }
+
+    public void AppendDict(string context,string dictPath)
+    {
+        object CombineTable(object model,object subModel)
+        {
+            if (!(model is TomlTable srcModel)) return subModel;
+            foreach(var item in (TomlTable)subModel)
+            {
+                if (!srcModel.ContainsKey(item.Key)) srcModel.Add(item.Key, item.Value);
+                else
+                {
+                    if(srcModel[item.Key] is TomlTable)
+                    {
+                        srcModel[item.Key] = CombineTable(srcModel[item.Key], ((TomlTable)subModel)[item.Key]);
+                    }else
+                    {
+                        srcModel[item.Key] = ((TomlTable)subModel)[item.Key];
+                    }
+                }
+            }
+            return srcModel;
+        }
+
+        if(!File.Exists(dictPath))
+            return;
+
+        string dictData = File.ReadAllText(dictPath);
+        TomlTable? subModel;
+        if (!Toml.TryToModel(dictData, out subModel, out var message))
+            return;
+
+        if (!model.ContainsKey(context)) model.Add(context, subModel);
+        else model[context] = CombineTable(model[context], subModel);
     }
 
     public string Translate(string text, IEnumerable<string> context)
@@ -31,6 +68,11 @@ internal class TomlTranslator : ITranslator
 
         foreach (string key in context.Concat([text]))
         {
+            {//fallback
+                object? tmp = null;
+                ((TomlTable)table).TryGetValue(text, out tmp);
+                text = (tmp is string) ? (string)tmp : text;
+            }
             if (!((TomlTable)table).TryGetValue(key, out table))
                 return text;
         }

--- a/TuneLab/I18N/TranslationManager.cs
+++ b/TuneLab/I18N/TranslationManager.cs
@@ -37,7 +37,37 @@ internal class TranslationManager
             string languageFile = Path.Combine(PathManager.TranslationsFolder, string.Format("{0}.toml", languageID));
             if (Path.Exists(languageFile))
             {
-                return new TomlTranslator(languageFile);
+                return new TomlTranslator(languageFile,new Dictionary<string, string>() {
+                    /*这里加Dictionary来Load插件语言包
+                     * 参数1：string，为插件名，也是Context的名字
+                     * 参数2：string，为插件语言包toml地址，可以为空。此部分需要和插件管理器联动，再看。
+                    */
+                    /*
+                     * 测试样例：
+                     * new TomlTranslator("主语言包.toml",new Dictionary<string,string>(){ {"VOCALOID5","插件语言包.toml"} });
+                     * 
+                     * 插件语言包内容：
+                     * NoteLanguage = "音符语言"
+                     * [G2PA]
+                     * JPN="日语"
+                     * CHS="中文"
+                     * 
+                     * 主要语言包内容：
+                     * [Dialog]
+                     * File="文件"
+                     * [VOCALOID5]
+                     * G2PA.CHS="汉语"
+                     * 
+                     * 加载完成后，实际TOML模型内容是这样的：
+                     * [Dialog]
+                     * File="文件"
+                     * [VOCALOID5]
+                     * NoteLanugae = "音符语言"
+                     * [VOCALOID5.G2PA]
+                     * JPN="日语"
+                     * CHS="汉语"
+                     */
+                });
             }
             else
             {


### PR DESCRIPTION
1.在public string Translate(string text, IEnumerable<string> context)中添加fallback代码，当子一级没有翻译但是父一级有时，返回父一级翻译。 2.添加了子翻译包支持，子翻译包用于插件翻译导入。
3.DEMO样例，请根据实际需求调整。