### PR TITLE
Linux extension install Support

### DIFF
--- a/ExtensionInstaller/Program.cs
+++ b/ExtensionInstaller/Program.cs
@@ -63,7 +63,7 @@ internal class Program
 
                 Console.WriteLine("Installing " + name + "...");
 
-                ZipFile.ExtractToDirectory(arg, dir, true);
+                ZipFileHelper.ExtractToDirectory(arg, dir);
                 Console.WriteLine(name + " has been successfully installed!\n");
             }
 

--- a/ExtensionInstaller/ZipFileHelper.cs
+++ b/ExtensionInstaller/ZipFileHelper.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExtensionInstaller
+{
+    internal class ZipFileHelper
+    {
+        public static void ExtractToDirectory(string sourceArchiveFileName, string destinationDirectoryName)
+        {
+            bool overflow = true;
+            using (var zip = ZipFile.Open(sourceArchiveFileName, ZipArchiveMode.Read))
+            {
+                foreach(var entry in zip.Entries) {
+                    string fullName=entry.FullName;
+                    string name = entry.Name;
+                    if (fullName.EndsWith("/") || fullName.EndsWith("\\"))
+                    {
+                        string splitChar = fullName.Last() + ""; 
+                        string[] splitNames = fullName.Split(splitChar).Where(d=>d.Length>0).ToArray(); 
+                        string targetDir = Path.Combine(destinationDirectoryName, Path.Combine(splitNames));
+                        if (!Directory.Exists(targetDir)) { Directory.CreateDirectory(targetDir); }
+                    }
+                    else if (fullName == name)
+                    {
+                        string targetFile = Path.Combine(destinationDirectoryName, fullName);
+                        string targetDir = Path.GetDirectoryName(targetFile);
+                        if (!Directory.Exists(targetDir)) { Directory.CreateDirectory(targetDir); }
+                        entry.ExtractToFile(targetFile,overflow);
+                    }
+                    else if (fullName.Length > name.Length)
+                    {
+                        string splitChar = fullName.Substring(fullName.Length - name.Length - 1, 1);
+                        string[] splitNames = fullName.Split(splitChar).Where(d => d.Length > 0).ToArray();
+                        string targetFile = Path.Combine(destinationDirectoryName, Path.Combine(splitNames));
+                        string targetDir = Path.GetDirectoryName(targetFile);
+                        if(!Directory.Exists(targetDir)) { Directory.CreateDirectory(targetDir); }
+                        entry.ExtractToFile(targetFile, overflow);
+                    }
+                };
+            }
+        }
+    }
+}

--- a/TuneLab/Resources/Translations/zh-CN.toml
+++ b/TuneLab/Resources/Translations/zh-CN.toml
@@ -96,6 +96,9 @@
 "Redo" = "重做"
 "Settings" = "设置"
 
+"Extensions" = "功能"
+"Install/Update" = "安装或更新"
+
 "Project" = "工程"
 "Add Track" = "添加轨道"
 "Import Track" = "导入工程轨道"

--- a/TuneLab/Resources/Translations/zh-TW.toml
+++ b/TuneLab/Resources/Translations/zh-TW.toml
@@ -95,6 +95,9 @@
 "Redo" = "重做"
 "Settings" = "設定"
 
+"Extensions" = "功能"
+"Install/Update" = "安装或更新"
+
 "Project" = "專案"
 "Add Track" = "新增軌道"
 "Import Track" = "匯入專案軌道"

--- a/TuneLab/UI/MainWindow/Editor/Editor.cs
+++ b/TuneLab/UI/MainWindow/Editor/Editor.cs
@@ -668,7 +668,8 @@ internal class Editor : DockPanel, PianoWindow.IDependency, TrackWindow.IDepende
         {
             List<string> args = ["-restart"];
             args.AddRange(installedExtension);
-            ProcessHelper.CreateProcess(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ExtensionInstaller.exe"), args);
+            string installer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ExtensionInstaller.exe" : "ExtensionInstaller";
+            ProcessHelper.CreateProcess(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, installer), args);
             this.Window().Close();
         };
         dialog.AddButton("No".Tr(TC.Dialog), ButtonType.Primary);

--- a/TuneLab/UI/MainWindow/Editor/Editor.cs
+++ b/TuneLab/UI/MainWindow/Editor/Editor.cs
@@ -648,7 +648,7 @@ internal class Editor : DockPanel, PianoWindow.IDependency, TrackWindow.IDepende
 
             try
             {
-                ZipFile.ExtractToDirectory(file, dir);
+                ZipFileHelper.ExtractToDirectory(file, dir);
                 ExtensionManager.Load(dir);
                 await this.ShowMessage("Tips".Tr(TC.Dialog), name + " has been successfully installed!".Tr(TC.Dialog));
             }

--- a/TuneLab/UI/MainWindow/Editor/Editor.cs
+++ b/TuneLab/UI/MainWindow/Editor/Editor.cs
@@ -825,7 +825,7 @@ internal class Editor : DockPanel, PianoWindow.IDependency, TrackWindow.IDepende
                     var fileList = files.Select(f => f.TryGetLocalPath()).Where(f => f != null).ToArray();
                     if (fileList != null) InstallExtensions(fileList);
                 });
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) menuBarItem.Items.Add(menuItem);
+                menuBarItem.Items.Add(menuItem);
             }
             menu.Items.Add(menuBarItem);
         }
@@ -857,6 +857,29 @@ internal class Editor : DockPanel, PianoWindow.IDependency, TrackWindow.IDepende
                 void UpdateHeader() => menuItem.SetName(AudioEngine.IsPlaying ? "Pause".Tr(TC.Menu) : "Play".Tr(TC.Menu));
                 AudioEngine.PlayStateChanged += UpdateHeader;
                 TranslationManager.CurrentLanguage.Modified.Subscribe(UpdateHeader);
+                menuBarItem.Items.Add(menuItem);
+            }
+            menu.Items.Add(menuBarItem);
+        }
+
+        {
+            var menuBarItem = new MenuItem { Foreground = Style.TEXT_LIGHT.ToBrush(), Focusable = false }.SetTrName("Extensions");
+            {
+                var menuItem = new MenuItem().SetTrName("Install/Update").SetAction(async () =>
+                {
+                    var topLevel = TopLevel.GetTopLevel(this);
+                    if (topLevel == null)
+                        return;
+                    var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                    {
+                        Title = "Open Tlx File",
+                        AllowMultiple = false,
+                        FileTypeFilter = [new("Tlx Package") { Patterns = ["*.tlx"] }]
+                    });
+                    if (files.IsEmpty()) return;
+                    var fileList = files.Select(f => f.TryGetLocalPath()).Where(f => f != null).ToArray();
+                    if (fileList != null) InstallExtensions(fileList);
+                });
                 menuBarItem.Items.Add(menuItem);
             }
             menu.Items.Add(menuBarItem);

--- a/TuneLab/UI/MainWindow/Editor/Editor.cs
+++ b/TuneLab/UI/MainWindow/Editor/Editor.cs
@@ -34,6 +34,9 @@ using System.Xml.Linq;
 using System.Text.Json;
 using TuneLab.I18N;
 using TuneLab.Configs;
+using Splat;
+using System.Reactive.Joins;
+using System.Runtime.InteropServices;
 
 namespace TuneLab.UI;
 
@@ -804,6 +807,24 @@ internal class Editor : DockPanel, PianoWindow.IDependency, TrackWindow.IDepende
                     settingsWindow.Show(this.Window());
                 });
                 menuBarItem.Items.Add(menuItem);
+            }
+            {
+                var menuItem = new MenuItem().SetTrName("Install Extensions").SetAction(async () =>
+                {
+                    var topLevel = TopLevel.GetTopLevel(this);
+                    if (topLevel == null)
+                        return;
+                    var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                    {
+                        Title = "Open Tlx File",
+                        AllowMultiple = false,
+                        FileTypeFilter = [new("Tlx Package") { Patterns = ["*.tlx"] }]
+                    });
+                    if (files.IsEmpty()) return;
+                    var fileList = files.Select(f => f.TryGetLocalPath()).Where(f => f != null).ToArray();
+                    if (fileList != null) InstallExtensions(fileList);
+                });
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) menuBarItem.Items.Add(menuItem);
             }
             menu.Items.Add(menuBarItem);
         }

--- a/TuneLab/Utils/ZipFileHelper.cs
+++ b/TuneLab/Utils/ZipFileHelper.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TuneLab.Utils
+{
+    internal class ZipFileHelper
+    {
+        public static void ExtractToDirectory(string sourceArchiveFileName, string destinationDirectoryName)
+        {
+            bool overflow = true;
+            using (var zip = ZipFile.Open(sourceArchiveFileName, ZipArchiveMode.Read))
+            {
+                foreach (var entry in zip.Entries)
+                {
+                    string fullName = entry.FullName;
+                    string name = entry.Name;
+                    if (fullName.EndsWith("/") || fullName.EndsWith("\\"))
+                    {
+                        string splitChar = fullName.Last() + "";
+                        string[] splitNames = fullName.Split(splitChar).Where(d => d.Length > 0).ToArray();
+                        string targetDir = Path.Combine(destinationDirectoryName, Path.Combine(splitNames));
+                        if (!Directory.Exists(targetDir)) { Directory.CreateDirectory(targetDir); }
+                    }
+                    else if (fullName == name)
+                    {
+                        string targetFile = Path.Combine(destinationDirectoryName, fullName);
+                        string targetDir = Path.GetDirectoryName(targetFile);
+                        if (!Directory.Exists(targetDir)) { Directory.CreateDirectory(targetDir); }
+                        entry.ExtractToFile(targetFile, overflow);
+                    }
+                    else if (fullName.Length > name.Length)
+                    {
+                        string splitChar = fullName.Substring(fullName.Length - name.Length - 1, 1);
+                        string[] splitNames = fullName.Split(splitChar).Where(d => d.Length > 0).ToArray();
+                        string targetFile = Path.Combine(destinationDirectoryName, Path.Combine(splitNames));
+                        string targetDir = Path.GetDirectoryName(targetFile);
+                        if (!Directory.Exists(targetDir)) { Directory.CreateDirectory(targetDir); }
+                        entry.ExtractToFile(targetFile, overflow);
+                    }
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
1.仅在Linux下启用：通过菜单项添加新插件。
2.手动解析Zip解压中对于目录的识别，实现合法的目录解压。