### PR TITLE
Upgrade packages and fix version mismatch

### DIFF
--- a/TuneLab/TuneLab.csproj
+++ b/TuneLab/TuneLab.csproj
@@ -17,20 +17,20 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.2.2" />
+		<PackageReference Include="Avalonia" Version="11.2.5" />
 		<PackageReference Include="Avalonia.Svg.Skia" Version="11.2.0.2" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.2" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.2" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.2.2" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.2.2" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.5" />
+		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.5" />
+		<PackageReference Include="Avalonia.ReactiveUI" Version="11.2.5" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.2.5" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.2" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.5" />
 		<PackageReference Include="BunLabs.NAudio.Flac" Version="2.0.1" />
 		<PackageReference Include="csharp-kana" Version="1.0.1" />
 		<PackageReference Include="csharp-pinyin" Version="1.0.1" />
 		<PackageReference Include="Flurl.Http" Version="4.0.2" />
 		<PackageReference Include="Markdown.Avalonia" Version="11.0.3-a1" />
-		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.13" />
 		<PackageReference Include="NAudio" Version="2.2.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NLayer.NAudioSupport" Version="1.4.0" />
@@ -39,8 +39,8 @@
 		<PackageReference Include="Svg.Skia" Version="2.0.0.4" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-		<PackageReference Include="Tomlyn" Version="0.17.0" />
-		<PackageReference Include="ZstdSharp.Port" Version="0.8.3" />
+		<PackageReference Include="Tomlyn" Version="0.18.0" />
+		<PackageReference Include="ZstdSharp.Port" Version="0.8.5" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Upgrades Avalonia and other packages for maintenance and potential bugfixes. Please note that `Microsoft.Extensions.ObjectPool` earlier was upgraded to a version made for .NET 9, which has the risk of introducing incompatibilities. I have changed it to be the latest .NET 8 version (8.0.13). Make sure to upgrade to the latest 8.0.X in the future instead.