### PR TITLE
Add toggles for checking updates and creating log files

### DIFF
--- a/TuneLab/Configs/Settings.cs
+++ b/TuneLab/Configs/Settings.cs
@@ -26,6 +26,8 @@ internal static class Settings
     public static NotifiableProperty<string> AudioDriver { get; } = DefaultSettings.AudioDriver;
     public static NotifiableProperty<string> AudioDevice { get; } = DefaultSettings.AudioDevice;
     public static NotifiableProperty<double> TrackHueChangeRate { get; } = DefaultSettings.TrackHueChangeRate;
+    public static NotifiableProperty<bool> LogFile { get; } = DefaultSettings.LogFile;
+    public static NotifiableProperty<bool> CheckUpdate { get; } = DefaultSettings.CheckUpdate;
     
     public static void Init(string path)
     {
@@ -56,6 +58,8 @@ internal static class Settings
         AudioDriver.Value = settingsFile.AudioDriver;
         AudioDevice.Value = settingsFile.AudioDevice;
         TrackHueChangeRate.Value = settingsFile.TrackHueChangeRate;
+        LogFile.Value = settingsFile.LogFile;
+        CheckUpdate.Value = settingsFile.CheckUpdate;
     }
 
     public static void Save(string path)
@@ -75,7 +79,9 @@ internal static class Settings
                 SampleRate = SampleRate,
                 AudioDriver = AudioDriver,
                 AudioDevice = AudioDevice,
-                TrackHueChangeRate = TrackHueChangeRate
+                TrackHueChangeRate = TrackHueChangeRate,
+                LogFile = LogFile,
+                CheckUpdate = CheckUpdate,
             }, JsonSerializerOptions);
 
             File.WriteAllText(path, content);

--- a/TuneLab/Configs/SettingsFile.cs
+++ b/TuneLab/Configs/SettingsFile.cs
@@ -20,4 +20,6 @@ internal class SettingsFile
     public string AudioDriver { get; set; } = string.Empty;
     public string AudioDevice { get; set; } = string.Empty;
     public double TrackHueChangeRate { get; set; } = 0;
+    public bool LogFile { get; set; } = true;
+    public bool CheckUpdate { get; set; } = true;
 }

--- a/TuneLab/Program.cs
+++ b/TuneLab/Program.cs
@@ -24,10 +24,16 @@ class Program
     [STAThread]
     public static void Main(string[] args)
     {
-        // init logger
-        Log.SetupLogger(new FileLogger(PathManager.LogFilePath));
-        Log.Info("Version: " + AppInfo.Version);
+        // init setting
+        Settings.Init(PathManager.SettingsFilePath);
 
+        // init logger
+        if (Settings.LogFile.Value)
+        {
+            Log.SetupLogger(new FileLogger(PathManager.LogFilePath));
+            Log.Info("Version: " + AppInfo.Version);
+        }
+        
         // check if other instance is running
         var lockFile = LockFile.Create(PathManager.LockFilePath);
         if (lockFile == null)
@@ -54,9 +60,6 @@ class Program
             Process.GetCurrentProcess().WaitForExit();
             return;
         }
-
-        // init setting
-        Settings.Init(PathManager.SettingsFilePath);
 
         // init translation
         TranslationManager.Init(PathManager.TranslationsFolder);

--- a/TuneLab/UI/MainWindow/Editor/Editor.cs
+++ b/TuneLab/UI/MainWindow/Editor/Editor.cs
@@ -145,7 +145,10 @@ internal class Editor : DockPanel, PianoWindow.IDependency, TrackWindow.IDepende
         RecentFilesManager.RecentFilesChanged += (sender, args) => UpdateRecentFilesMenu();
 
         NewProject();
-        CheckUpdate();
+        if (Settings.CheckUpdate.Value)
+        {
+            CheckUpdate();
+        }
     }
 
     ~Editor()

--- a/TuneLab/UI/Settings/SettingsWindow.axaml
+++ b/TuneLab/UI/Settings/SettingsWindow.axaml
@@ -6,7 +6,7 @@
         x:Class="TuneLab.UI.SettingsWindow"
         Title="Settings - TuneLab"
 		Width="600"
-		Height="720"
+		Height="800"
 		ExtendClientAreaChromeHints="NoChrome"
 		ExtendClientAreaTitleBarHeightHint="40"
 		ExtendClientAreaToDecorationsHint="True">

--- a/TuneLab/UI/Settings/SettingsWindow.axaml.cs
+++ b/TuneLab/UI/Settings/SettingsWindow.axaml.cs
@@ -17,6 +17,7 @@ using Avalonia.Platform.Storage;
 using TuneLab.Base.Event;
 using TuneLab.Audio;
 using TuneLab.Base.Structures;
+using CheckBox = TuneLab.GUI.Components.CheckBox;
 
 namespace TuneLab.UI;
 
@@ -227,6 +228,32 @@ internal partial class SettingsWindow : Window
             }
             {
                 var name = new TextBlock() { Text = "Track Hue Change Rate (degree/second)".Tr(this) + ": ", VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
+                panel.AddDock(name);
+            }
+            listView.Content.Children.Add(panel);
+        }
+        {
+            var panel = new DockPanel() { Margin = new(24, 12) };
+            {
+                var checkBox = new CheckBox();
+                checkBox.Bind(Settings.CheckUpdate, false, s);
+                panel.AddDock(checkBox, Dock.Right);
+            }
+            {
+                var name = new TextBlock() { Text = "Check For Updates On Start".Tr(this) + ": ", VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
+                panel.AddDock(name);
+            }
+            listView.Content.Children.Add(panel);
+        }
+        {
+            var panel = new DockPanel() { Margin = new(24, 12) };
+            {
+                var checkBox = new CheckBox();
+                checkBox.Bind(Settings.LogFile, false, s);
+                panel.AddDock(checkBox, Dock.Right);
+            }
+            {
+                var name = new TextBlock() { Text = "Enable Logging To File".Tr(this) + ": ", VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
                 panel.AddDock(name);
             }
             listView.Content.Children.Add(panel);


### PR DESCRIPTION
Adds two toggles that control the automatic searching of updates on startup and the creation of log files, in order to give users more control. Log files especially can end up exceeding dozens of files easily. Both are enabled by default.

Tested and working.

<img width="601" alt="Screenshot 2025-04-20 at 03 46 58" src="https://github.com/user-attachments/assets/ae38e890-2602-434f-ac29-1e56048d73c5" />



Moved the location of the setting initialization `Settings.Init(PathManager.SettingsFilePath);` in [program.cs](https://github.com/RedBlackAka/TuneLab/blob/toggles/TuneLab/Program.cs) in order to make it work for logging, this does not change behavior unexpectedly and I did not encounter any bugs.