### PR TITLE
feat: minimal MacOS Support

### DIFF
--- a/ExtensionInstaller/Program.cs
+++ b/ExtensionInstaller/Program.cs
@@ -124,7 +124,10 @@ internal class Program
                 Console.WriteLine(name + " has been successfully installed!\n");
             }
 
-            if (restart) Process.Start(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TuneLab.exe"));
+            if (restart) {
+                var tunelabExeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "TuneLab.exe" : "TuneLab";
+                Process.Start(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, tunelabExeName));
+            }
         }
         catch (Exception ex)
         {

--- a/TuneLab/Program.cs
+++ b/TuneLab/Program.cs
@@ -85,12 +85,24 @@ class Program
             .UseReactiveUI()
             .With(new FontManagerOptions()
             {
+                DefaultFamilyName = Settings.Language.Value == "ja-JP" ? JapaneseUIFontFamilyName() : null,
                 FontFallbacks =
                 [
                     (Settings.Language.Value == "ja-JP") ?
-                        new FontFallback() { FontFamily = "Yu Gothic UI" } :
+                        OperatingSystem.IsWindows() ?
+                            new FontFallback() { FontFamily = "Yu Gothic UI" } :
+                        OperatingSystem.IsMacOS() ?
+                            new FontFallback() { FontFamily = JapaneseUIFontFamilyName() } :
+                            new FontFallback() { FontFamily = "Noto Sans CJK JP" } :
                         new FontFallback() { FontFamily = "Microsoft YaHei" },
                 ]
             });
+    }
+
+    static string JapaneseUIFontFamilyName()
+    {
+        return OperatingSystem.IsWindows() ? "Yu Gothic UI" :
+            OperatingSystem.IsMacOS() ? "Hiragino Sans" :
+            "Noto Sans CJK JP";
     }
 }

--- a/TuneLab/TuneLab.csproj
+++ b/TuneLab/TuneLab.csproj
@@ -22,14 +22,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.2.5" />
-		<PackageReference Include="Avalonia.Svg.Skia" Version="11.2.0.2" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.5" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.5" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.2.5" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.2.5" />
+		<PackageReference Include="Avalonia" Version="11.3.15" />
+		<PackageReference Include="Avalonia.Svg.Skia" Version="11.3.0" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.15" />
+		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.15" />
+		<PackageReference Include="Avalonia.ReactiveUI" Version="11.3.8" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.3.15" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.5" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.15" />
 		<PackageReference Include="BunLabs.NAudio.Flac" Version="2.0.1" />
 		<PackageReference Include="csharp-kana" Version="1.0.1" />
 		<PackageReference Include="csharp-pinyin" Version="1.0.1" />
@@ -41,7 +41,7 @@
 		<PackageReference Include="NLayer.NAudioSupport" Version="1.4.0" />
 		<PackageReference Include="PinYinConverterCore" Version="1.0.2" />
 		<PackageReference Include="ppy.SDL2-CS" Version="1.0.741-alpha" />
-		<PackageReference Include="Svg.Skia" Version="2.0.0.4" />
+		<PackageReference Include="Svg.Skia" Version="3.0.2" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="Tomlyn" Version="0.18.0" />


### PR DESCRIPTION
This PR:
- upgrades Avalonia to 11.3 to fix https://github.com/AvaloniaUI/Avalonia/issues/10658 .
- uses `TuneLab` as executable name for Extension Installer.